### PR TITLE
Fix CentOS installation

### DIFF
--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -23,7 +23,7 @@
   yum:
     name: "{{ item }}"
     state: present
-  environment: postgresql_env
+  environment: "{{postgresql_env}}"
   with_items:
     - "postgresql{{ postgresql_version_terse }}-server"
     - "postgresql{{ postgresql_version_terse }}"
@@ -32,5 +32,5 @@
   yum:
     name: pgtune
     state: present
-  environment: postgresql_env
+  environment: "{{postgresql_env}}"
   when: postgresql_pgtune


### PR DESCRIPTION
Ansible complains of `Using bare variables for environment is deprecated.` when the host is CentOS. This commit, by @zamotivator, fixes that.
