### PR TITLE
Install postgresql-contrib modules on EL-distros

### DIFF
--- a/tasks/install_yum.yml
+++ b/tasks/install_yum.yml
@@ -27,6 +27,7 @@
   with_items:
     - "postgresql{{ postgresql_version_terse }}-server"
     - "postgresql{{ postgresql_version_terse }}"
+    - "postgresql{{ postgresql_version_terse }}-contrib"
 
 - name: PostgreSQL | PGTune
   yum:


### PR DESCRIPTION
Required for hstore and other extensions.
