### PR TITLE
Support psycopg2 on python3

### DIFF
--- a/tasks/extensions/dev_headers.yml
+++ b/tasks/extensions/dev_headers.yml
@@ -1,6 +1,6 @@
 # file: postgresql/tasks/extensions/dev_headers.yml
 
-- name: PostgreSQL | Extensions | Make sure the development headers are installed
+- name: PostgreSQL | Extensions | Make sure the development headers are installed (apt)
   apt:
     name: libpq-dev
     state: present
@@ -8,3 +8,11 @@
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
   notify:
     - restart postgresql
+  when: ansible_pkg_mgr == "apt"
+
+- name: PostgreSQL | Extensions | Make sure the development headers are installed (yum)
+  yum:
+    name: "postgresql{{ postgresql_version_terse }}-devel"
+    state: present
+  environment: "{{postgresql_env}}"
+  when: ansible_pkg_mgr == "yum"

--- a/tasks/link_executables.yml
+++ b/tasks/link_executables.yml
@@ -1,0 +1,9 @@
+# file: postgresql/tasks/link_executable.yml
+
+- name: Link postgres executables to /usr/bin
+  alternatives:
+    path: "{{ postgresql_bin_directory}}/{{ item }}"
+    link: "/usr/bin/{{ item }}"
+    name: "{{ item }}"
+  with_items:
+    - "pg_config"


### PR DESCRIPTION
Many tools, like psycopg2, require pg_config to be in the path. This
pull request uses alternatives to link pg_config into /usr/bin, where other
postgres binaries are linked to.

Also the dev headers extension only worked on Ubuntu so I've extended it to support Centos/RHEL.
